### PR TITLE
Improve login and register design

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ db.serialize(() => {
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 app.use(bodyParser.urlencoded({ extended: false }));
+app.use(express.static(path.join(__dirname, 'public')));
 app.use(session({
   secret: 'secret-key',
   resave: false,

--- a/public/auth.css
+++ b/public/auth.css
@@ -1,0 +1,85 @@
+:root {
+  --gray: #f4f4f4;
+  --red: #e63946;
+  --white: #ffffff;
+  --green: #2a9d8f;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  background: var(--gray);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  margin: 0;
+  padding: 1rem;
+}
+
+.auth-container {
+  background: var(--white);
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  width: 90%;
+  max-width: 400px;
+}
+
+h1 {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: #333;
+}
+
+input[type="text"],
+input[type="password"] {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+button {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: var(--green);
+  border: none;
+  color: var(--white);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+button:hover {
+  background-color: #23867e;
+}
+
+.auth-link {
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.auth-link a {
+  color: var(--red);
+  text-decoration: none;
+}
+
+.auth-link a:hover {
+  text-decoration: underline;
+}
+
+.error {
+  color: var(--red);
+  text-align: center;
+  margin-bottom: 1rem;
+}

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,17 +1,25 @@
 <!DOCTYPE html>
-<html>
+<html lang="de">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login</title>
+  <link rel="stylesheet" href="/auth.css">
 </head>
 <body>
-  <h1>Login</h1>
-  <% if (error) { %><p style="color:red"><%= error %></p><% } %>
-  <form method="post" action="/login">
-    <label>Benutzername:<br><input type="text" name="username"></label><br>
-    <label>Passwort:<br><input type="password" name="password"></label><br>
-    <button type="submit">Login</button>
-  </form>
-  <p>Noch kein Konto? <a href="/register">Registrieren</a></p>
+  <div class="auth-container">
+    <h1>Login</h1>
+    <% if (error) { %><p class="error"><%= error %></p><% } %>
+    <form method="post" action="/login">
+      <label>Benutzername:
+        <input type="text" name="username" required>
+      </label>
+      <label>Passwort:
+        <input type="password" name="password" required>
+      </label>
+      <button type="submit">Login</button>
+    </form>
+    <div class="auth-link">Noch kein Konto? <a href="/register">Registrieren</a></div>
+  </div>
 </body>
 </html>

--- a/views/register.ejs
+++ b/views/register.ejs
@@ -1,17 +1,25 @@
 <!DOCTYPE html>
-<html>
+<html lang="de">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Registrieren</title>
+  <link rel="stylesheet" href="/auth.css">
 </head>
 <body>
-  <h1>Registrieren</h1>
-  <% if (error) { %><p style="color:red"><%= error %></p><% } %>
-  <form method="post" action="/register">
-    <label>Benutzername:<br><input type="text" name="username"></label><br>
-    <label>Passwort:<br><input type="password" name="password"></label><br>
-    <button type="submit">Registrieren</button>
-  </form>
-  <p>Schon ein Konto? <a href="/login">Login</a></p>
+  <div class="auth-container">
+    <h1>Registrieren</h1>
+    <% if (error) { %><p class="error"><%= error %></p><% } %>
+    <form method="post" action="/register">
+      <label>Benutzername:
+        <input type="text" name="username" required>
+      </label>
+      <label>Passwort:
+        <input type="password" name="password" required>
+      </label>
+      <button type="submit">Registrieren</button>
+    </form>
+    <div class="auth-link">Schon ein Konto? <a href="/login">Login</a></div>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Serve shared authentication styles via new `public/auth.css`
- Link login and registration templates to shared stylesheet and require form fields for a cleaner layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e2864d92083319b3819b465ab8eba